### PR TITLE
gh: aligned workflow permissions with smallstep/workflows#324

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ concurrency:
 
 jobs:
   ci:
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     uses: smallstep/workflows/.github/workflows/goCI.yml@main
     with:
       only-latest-golang: false

--- a/.github/workflows/code-scan-cron.yml
+++ b/.github/workflows/code-scan-cron.yml
@@ -4,6 +4,9 @@ on:
 
 jobs:
   code-scan:
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     uses: smallstep/workflows/.github/workflows/code-scan.yml@main
-    secrets:
-      GITLEAKS_LICENSE_KEY: ${{ secrets.GITLEAKS_LICENSE_KEY }}
+    secrets: inherit


### PR DESCRIPTION
This PR amends the workflows configuration to be more inline with smallstep/workflows#324. Specifically, it grants `actions: read`, `contents: read`, and `security-events: write` to the `ci` job, which calls `goCI.yml` with `run-codeql: true`; without these scopes the CodeQL sub-job cannot upload its findings.
